### PR TITLE
Add CLI migration option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ compileJava {
 }
 
 dependencies {
+    compile ratpack.dependency("hikari")
     compile ratpack.dependency("guice")
     compile "org.liquibase:liquibase-core:3.5.3"
     compile 'com.google.code.findbugs:jsr305:3.0.1'
@@ -53,4 +54,7 @@ dependencies {
 
     testRuntime 'cglib:cglib-nodep:3.2.4'
     testRuntime 'org.objenesis:objenesis:2.4'
+    testRuntime 'com.h2database:h2:1.4.193'
+    testRuntime 'org.slf4j:slf4j-api:1.7.21'
+    testRuntime 'ch.qos.logback:logback-classic:1.1.7'
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    patch: false
+    project:
+      default:
+        target: '65'
+    changes: false
+comment:
+  layout: "header, diff, sunburst, uncovered"
+  behavior: new

--- a/src/main/java/smartthings/ratpack/liquibase/Migrate.java
+++ b/src/main/java/smartthings/ratpack/liquibase/Migrate.java
@@ -1,0 +1,50 @@
+package smartthings.ratpack.liquibase;
+
+import com.google.common.io.Resources;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import ratpack.config.ConfigData;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Execute Liquibase migrations outside of Ratpack startup.
+ */
+public class Migrate {
+    public static void main(String[] args) {
+        if (args.length != 3) {
+            System.err.println("Usage: smartthings.ratpack.liquibase.Migrate <username> <password> <config>");
+            System.exit(1);
+        }
+        try {
+            Path path = Paths.get(args[2]);
+            ConfigData configData = Files.exists(path) ? fromPath(path) : fromClasspath(args[2]);
+            HikariConfig hikariConfig = configData.get("/db", HikariConfig.class);
+            hikariConfig.setUsername(args[0]);
+            hikariConfig.setPassword(args[1]);
+            HikariDataSource dataSource = new HikariDataSource(hikariConfig);
+            try {
+                LiquibaseModule.Config liquibaseConfig = configData.get("/liquibase", LiquibaseModule.Config.class);
+                new LiquibaseService(liquibaseConfig, dataSource).migrate();
+            } finally {
+                dataSource.close();
+            }
+        } catch (Exception ex) {
+            System.err.println("Migration error:");
+            ex.printStackTrace(System.err);
+            System.exit(42);
+        }
+    }
+
+    private static ConfigData fromPath(Path path) throws Exception {
+        return ConfigData.of(c -> c.yaml(path));
+    }
+
+    private static ConfigData fromClasspath(String resourceName) throws Exception {
+        URL resource = Resources.getResource(resourceName);
+        return ConfigData.of(c -> c.yaml(resource));
+    }
+}

--- a/src/test/resources/migrations.xml
+++ b/src/test/resources/migrations.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+    <changeSet id="test-table" author="mrobinet">
+        <createTable tableName="ratpack-liquibase">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true" unique="true"/>
+            </column>
+            <column name="message" type="varchar(36)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/test.yml
+++ b/src/test/resources/test.yml
@@ -1,0 +1,9 @@
+db:
+  driverClassName: org.h2.jdbcx.JdbcDataSource
+  username: sa
+  password: ''
+  jdbcUrl: 'jdbc:h2:mem:test;INIT=CREATE SCHEMA IF NOT EXISTS test'
+
+liquibase:
+  autoMigrate: false
+  migrationFile: 'migrations.xml'


### PR DESCRIPTION
Adding CLI migration so that migration can be performed during provisioning.

Command would look something like this:
```
java -cp service.jar smartthings.ratpack.liquibase.Migrate username password service.yml
```
...where service.yml is either a file path or classpath resource to load DB connection settings from. Username and password are separate parameters to support performing the migration with a user that has elevated privileges.