### PR TITLE
Stop service startup on migration failures or if migrations are not up to date

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.2'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.14.0'
         classpath "gradle.plugin.io.ratpack:ratpack-gradle:${ratpackVersion}"
     }
 }
@@ -48,13 +48,13 @@ dependencies {
     compile ratpack.dependency("hikari")
     compile ratpack.dependency("guice")
     compile "org.liquibase:liquibase-core:3.5.3"
-    compile 'com.google.code.findbugs:jsr305:3.0.1'
+    compile 'com.google.code.findbugs:annotations:3.0.1u2'
 
-    testCompile 'org.spockframework:spock-core:1.1-groovy-2.4-rc-2'
+    testCompile 'org.spockframework:spock-core:1.1-groovy-2.4-rc-4'
 
-    testRuntime 'cglib:cglib-nodep:3.2.4'
-    testRuntime 'org.objenesis:objenesis:2.4'
-    testRuntime 'com.h2database:h2:1.4.193'
-    testRuntime 'org.slf4j:slf4j-api:1.7.21'
-    testRuntime 'ch.qos.logback:logback-classic:1.1.7'
+    testRuntime 'cglib:cglib-nodep:3.2.5'
+    testRuntime 'org.objenesis:objenesis:2.5.1'
+    testRuntime 'com.h2database:h2:1.4.195'
+    testRuntime 'org.slf4j:slf4j-api:1.7.25'
+    testRuntime 'ch.qos.logback:logback-classic:1.2.3'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-ratpackVersion=1.4.3
+ratpackVersion=1.4.6


### PR DESCRIPTION
Ansible isn't reliably reporting Liquibase failures right now, so this is a check to prevent new clusters from going healthy if any unrun migrations exist.

Throws `LiquibaseException` on migration failures or if unrun migrations exist. This will prevent Ratpack from starting the service in production mode. In development mode errors are seen, but service still starts.