### PR TITLE
[IOTEVENT-1120] force exit after migration

### DIFF
--- a/src/main/java/smartthings/ratpack/liquibase/Migrate.java
+++ b/src/main/java/smartthings/ratpack/liquibase/Migrate.java
@@ -35,6 +35,7 @@ public class Migrate {
                 new LiquibaseService(liquibaseConfig, dataSource).migrate();
             } finally {
                 dataSource.close();
+                System.exit(0);
             }
         } catch (Exception ex) {
             System.err.println("Migration error:");


### PR DESCRIPTION
Currently when services using https://github.com/reactor/reactor-addons/tree/master/reactor-logback, 
after migration is finished, the process will hang for ever.  